### PR TITLE
fix:(json) TypeError: the JSON object must be str, not 'bytes', json iss...

### DIFF
--- a/pymystem3/mystem.py
+++ b/pymystem3/mystem.py
@@ -253,7 +253,7 @@ class Mystem(object):
                 try:
                     out = self._procout.read()
                     sio.write(out)
-                    obj = json.loads(sio.getvalue())
+                    obj = json.loads(sio.getvalue().decode('utf-8'))
                     break
                 except (IOError, ValueError):
                     rd, _, _ = select.select([self._procout_no], [], [], 30)


### PR DESCRIPTION
Fixes my python3.4 issue on Ubuntu 14.04 with json load.
Bug behave like http://stackoverflow.com/questions/6862770/python-3-let-json-object-accept-bytes-or-let-urlopen-output-strings
